### PR TITLE
Bug/support multiple uri params

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,4 +6,10 @@
             <directory>./test/Blueman/</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory>./src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/test/Blueman/ConvertCommandTest.php
+++ b/test/Blueman/ConvertCommandTest.php
@@ -64,4 +64,152 @@ class ConvertCommandTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($message, 'Your API Blueprint needs to be build with Snow Crash 0.9.0 or higher.');
     }
+
+    public function testParsingUriWithoutParams()
+    {
+        $cmd = new ConvertCommand();
+        $method = $this->getAccessibleParseUriMethod();
+        
+        $resource = new stdClass();
+        $resource->uriTemplate = '/players';
+        $action = new stdClass();
+        
+        $result = $method->invokeArgs($cmd, [$resource, $action]);
+        
+        $this->assertEquals('/players', $result);
+    }
+
+    public function testParsingUriWithSingleQueryParam()
+    {
+        $cmd = new ConvertCommand();
+        $method = $this->getAccessibleParseUriMethod();
+
+        $resource = new stdClass();
+        $resource->uriTemplate = '/players{?name}';
+        
+        $nameParam = new stdClass();
+        $nameParam->name = 'name';
+        $nameParam->example = 'John';
+
+        $action = new stdClass();
+        $action->parameters = [$nameParam];
+
+        $result = $method->invokeArgs($cmd, [$resource, $action]);
+
+        $this->assertEquals('/players?name=John', $result);
+    }
+
+    public function testParsingUriWithMultipleQueryParams()
+    {
+        $cmd = new ConvertCommand();
+        $method = $this->getAccessibleParseUriMethod();
+
+        $resource = new stdClass();
+        $resource->uriTemplate = '/players{?name,age}';
+        
+        $nameParam = new stdClass();
+        $nameParam->name = 'name';
+        $nameParam->example = 'John';
+        
+        $ageParam = new stdClass();
+        $ageParam->name = 'age';
+        $ageParam->example = 25;
+
+        $action = new stdClass();
+        $action->parameters = [$nameParam, $ageParam];
+
+        $result = $method->invokeArgs($cmd, [$resource, $action]);
+
+        $this->assertEquals('/players?name=John&age=25', $result);
+    }
+
+    public function testParsingUriWithSingleUriParam()
+    {
+        $cmd = new ConvertCommand();
+        $method = $this->getAccessibleParseUriMethod();
+
+        $resource = new stdClass();
+        $resource->uriTemplate = '/players/{name}';
+        
+        $nameParam = new stdClass();
+        $nameParam->name = 'name';
+        $nameParam->example = 'John';
+
+        $action = new stdClass();
+        $action->parameters = [$nameParam];
+
+        $result = $method->invokeArgs($cmd, [$resource, $action]);
+
+        $this->assertEquals('/players/John', $result);
+    }
+
+    public function testParsingUriWithMultipleUriParams()
+    {
+        $cmd = new ConvertCommand();
+        $method = $this->getAccessibleParseUriMethod();
+
+        $resource = new stdClass();
+        $resource->uriTemplate = '/players/{name}/games/{game_id}';
+        
+        $nameParam = new stdClass();
+        $nameParam->name = 'name';
+        $nameParam->example = 'John';
+        
+        $gameParam = new stdClass();
+        $gameParam->name = 'game_id';
+        $gameParam->example = '52387';
+
+        $action = new stdClass();
+        $action->parameters = [$nameParam, $gameParam];
+
+        $result = $method->invokeArgs($cmd, [$resource, $action]);
+
+        $this->assertEquals('/players/John/games/52387', $result);
+    }
+
+    public function testParsingUriWithMultipleUriAndQueryParams()
+    {
+        $cmd = new ConvertCommand();
+        $method = $this->getAccessibleParseUriMethod();
+
+        $resource = new stdClass();
+        $resource->uriTemplate = '/players/{name}/games/{game_id}{?filter,locale}';
+        
+        $nameParam = new stdClass();
+        $nameParam->name = 'name';
+        $nameParam->example = 'John';
+        
+        $gameParam = new stdClass();
+        $gameParam->name = 'game_id';
+        $gameParam->example = '52387';
+        
+        $filterParam = new stdClass();
+        $filterParam->name = 'filter';
+        $filterParam->example = 'flunkyball';
+        
+        $localeParam = new stdClass();
+        $localeParam->name = 'locale';
+        $localeParam->example = 'US';
+
+        $action = new stdClass();
+        $action->parameters = [$nameParam, $gameParam, $filterParam, $localeParam];
+
+        $result = $method->invokeArgs($cmd, [$resource, $action]);
+
+        $this->assertEquals('/players/John/games/52387?filter=flunkyball&locale=US', $result);
+    }
+
+    /**
+     * Helper to call `parseUri` on `ConvertCommand`
+     * 
+     * @return ReflectionMethod Accessible `ConvertCommand::parseUri`
+     */
+    private function getAccessibleParseUriMethod()
+    {
+        $reflection = new ReflectionClass('\Blueman\Console\Command\ConvertCommand');
+        $method = $reflection->getMethod('parseUri');
+        $method->setAccessible(true);
+        
+        return $method;
+    }
 }

--- a/test/Blueman/ConvertCommandTest.php
+++ b/test/Blueman/ConvertCommandTest.php
@@ -194,7 +194,7 @@ class ConvertCommandTest extends \PHPUnit_Framework_TestCase
         $action = new stdClass();
         $action->parameters = array($nameParam, $gameParam, $filterParam, $localeParam);
 
-        $result = $method->invokeArgs($cmd, [$resource, $action]);
+        $result = $method->invokeArgs($cmd, array($resource, $action));
 
         $this->assertEquals('/players/John/games/52387?filter=flunkyball&locale=US', $result);
     }

--- a/test/Blueman/ConvertCommandTest.php
+++ b/test/Blueman/ConvertCommandTest.php
@@ -74,7 +74,7 @@ class ConvertCommandTest extends \PHPUnit_Framework_TestCase
         $resource->uriTemplate = '/players';
         $action = new stdClass();
         
-        $result = $method->invokeArgs($cmd, [$resource, $action]);
+        $result = $method->invokeArgs($cmd, array($resource, $action));
         
         $this->assertEquals('/players', $result);
     }
@@ -92,9 +92,9 @@ class ConvertCommandTest extends \PHPUnit_Framework_TestCase
         $nameParam->example = 'John';
 
         $action = new stdClass();
-        $action->parameters = [$nameParam];
+        $action->parameters = array($nameParam);
 
-        $result = $method->invokeArgs($cmd, [$resource, $action]);
+        $result = $method->invokeArgs($cmd, array($resource, $action));
 
         $this->assertEquals('/players?name=John', $result);
     }
@@ -116,9 +116,9 @@ class ConvertCommandTest extends \PHPUnit_Framework_TestCase
         $ageParam->example = 25;
 
         $action = new stdClass();
-        $action->parameters = [$nameParam, $ageParam];
+        $action->parameters = array($nameParam, $ageParam);
 
-        $result = $method->invokeArgs($cmd, [$resource, $action]);
+        $result = $method->invokeArgs($cmd, array($resource, $action));
 
         $this->assertEquals('/players?name=John&age=25', $result);
     }
@@ -136,9 +136,9 @@ class ConvertCommandTest extends \PHPUnit_Framework_TestCase
         $nameParam->example = 'John';
 
         $action = new stdClass();
-        $action->parameters = [$nameParam];
+        $action->parameters = array($nameParam);
 
-        $result = $method->invokeArgs($cmd, [$resource, $action]);
+        $result = $method->invokeArgs($cmd, array($resource, $action));
 
         $this->assertEquals('/players/John', $result);
     }
@@ -160,9 +160,9 @@ class ConvertCommandTest extends \PHPUnit_Framework_TestCase
         $gameParam->example = '52387';
 
         $action = new stdClass();
-        $action->parameters = [$nameParam, $gameParam];
+        $action->parameters = array($nameParam, $gameParam);
 
-        $result = $method->invokeArgs($cmd, [$resource, $action]);
+        $result = $method->invokeArgs($cmd, array($resource, $action));
 
         $this->assertEquals('/players/John/games/52387', $result);
     }
@@ -192,7 +192,7 @@ class ConvertCommandTest extends \PHPUnit_Framework_TestCase
         $localeParam->example = 'US';
 
         $action = new stdClass();
-        $action->parameters = [$nameParam, $gameParam, $filterParam, $localeParam];
+        $action->parameters = array($nameParam, $gameParam, $filterParam, $localeParam);
 
         $result = $method->invokeArgs($cmd, [$resource, $action]);
 


### PR DESCRIPTION
The command now supports multiple URI params, e.g. `/players/{name}/{age}` and URI params as well as query params at the same time, e.g. `/players/{name}/{age}{?filter,locale}`

Furthermore I added extensive unit testing for parsing URI's which cover most of the scenarios I often run into.

While working on the code, I split the original `parseUri` method into multiple sub-methods. `parseUri` itself just checks for URI and query params and replaces them.

I'd suggest creating **version 1.1.3** after merging this.