### PR TITLE
Fixed Snowcrash version number requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ Blueman can also be installed using Composer if you prefer that:
 $ composer create-project pixelfusion/blueman your-project-name
 ```
 
+## Prerequisites
+
+The API Blueprint JSON file that you want to convert with Blueman should be created using [Drafter](https://github.com/apiaryio/drafter). By default Drafter creates `refract` formatted JSON files but Blueman only supports the `AST` format. You will have to force Drafter to use `AST` by passing the `-t` parameter, for example:
+
+```sh
+drafter -f json -t ast -o api.json api.md
+```
+
+**Note:** As of December 2015 the API Blueprint AST format has been deprecated. The API Blueprint AST has been superseded by [API Description Refract Namespace](https://github.com/refractproject/refract-spec/blob/master/namespaces/api-description-namespace.md). At this point Blueman only supports the `AST` format so as soon as Drafter drops support for generating `AST` formatted files, `Blueman` won't work anymore. Pull Requests to add support for the `refract` format are highly appreciated!
+
 ## Usage
 
 To generate a Postman collection you run the `convert` command. For example, if the API Blueprint JSON file you generated is called `api.json` you would execute the following command:

--- a/src/Blueman/Console/Command/ConvertCommand.php
+++ b/src/Blueman/Console/Command/ConvertCommand.php
@@ -6,12 +6,12 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
-
 use Rhumsaa\Uuid\Uuid;
 
 class ConvertCommand extends Command
 {
-    protected function configure() {
+    protected function configure()
+    {
         $this->setName("convert")
             ->setDescription("Converts an API Blueprint JSON file into a Postman collection")
             ->addArgument(
@@ -20,24 +20,24 @@ class ConvertCommand extends Command
                 'The JSON file to convert'
             )
             ->addOption(
-               'path',
-               null,
-               InputOption::VALUE_OPTIONAL,
-               'The absolute path pointing to the location of your JSON file.',
-               getcwd()
+                'path',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'The absolute path pointing to the location of your JSON file.',
+                getcwd()
             )
             ->addOption(
-               'output',
-               null,
-               InputOption::VALUE_OPTIONAL,
-               'The location (including the filename) of where your collection should be saved.',
-               sprintf('%s/collection.json', getcwd())
+                'output',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'The location (including the filename) of where your collection should be saved.',
+                sprintf('%s/collection.json', getcwd())
             )
             ->addOption(
-               'host',
-               null,
-               InputOption::VALUE_REQUIRED,
-               'The base host of your API (e.g. https://api.example.com/v1).'
+                'host',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'The base host of your API (e.g. https://api.example.com/v1).'
             )
             ->setHelp(<<<EOT
 The <info>convert</info> command converts an API Blueprint JSON file into a Postman collection.
@@ -59,12 +59,13 @@ EOT
 
         $blueprint = json_decode(file_get_contents($file));
 
-        $version = (float)$blueprint->_version;
-        if ($version < 2.0) {
+        if (isset($blueprint->ast) === false) {
             throw new \Exception(
-                'Your API Blueprint needs to be build with Snow Crash 0.9.0 or higher.'
+                'Your API Blueprint file is not in the AST format. When parsing your API Blueprint file with Drafter add the -f flag to set the parse result type, e.g. `drafter -f json -t ast -o api.json api.md`.'
             );
         }
+
+        $blueprint = $blueprint->ast;
 
         $collection = array();
         $collection['id'] = (string)Uuid::uuid4();
@@ -197,7 +198,7 @@ EOT
 
         foreach ($urlParameters as $key => $urlParameter) {
             $parameter = $this->getParameter($urlParameter, $parameters);
-            if (is_object($parameter) && property_exists($parameter, 'example')){
+            if (is_object($parameter) && property_exists($parameter, 'example')) {
                 $urlParameters[$key] = $urlParameter . '=' . $parameter->example;
             }
         }

--- a/test/Blueman/ConvertCommandTest.php
+++ b/test/Blueman/ConvertCommandTest.php
@@ -48,13 +48,13 @@ class ConvertCommandTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp('/API Blueprint file \[.*\] not found/', $message);
     }
 
-    public function testOutdatedSnowCrashException()
+    public function testNonAstException()
     {
         try {
             $this->commandTester->execute(
                 array(
                     'command' => $this->command->getName(),
-                    'input-file' => 'api_outdated.json',
+                    'input-file' => 'api_non-ast.json',
                     '--path' => getcwd().'/test'
                 )
             );
@@ -62,7 +62,7 @@ class ConvertCommandTest extends \PHPUnit_Framework_TestCase
             $message = $e->getMessage();
         }
 
-        $this->assertEquals($message, 'Your API Blueprint needs to be build with Snow Crash 0.9.0 or higher.');
+        $this->assertContains('Your API Blueprint file is not in the AST format.', $message);
     }
 
     public function testParsingUriWithoutParams()

--- a/test/api.json
+++ b/test/api.json
@@ -1,71 +1,74 @@
 {
-  "_version": "2.0",
-  "metadata": [
-    {
-      "name": "HOST",
-      "value": "https://foosball.pixelfusion.co.nz/v1"
-    },
-    {
-      "name": "FORMAT",
-      "value": "1A"
-    }
-  ],
-  "name": "Foosball API",
-  "description": "## Introduction\n\nThis is a simple API for keeping Foosball scores. It doesn't really exists and is just created to demonstrate the the <a href=\"http://git.io/api-blueprint-parser\" target=\"_blank\">API Blueprint Parser</a>.\n\n",
-  "resourceGroups": [
-    {
-      "name": "Players",
-      "description": "",
-      "resources": [
-        {
-          "name": "Player",
-          "description": "",
-          "uriTemplate": "/players",
-          "model": {},
-          "parameters": [],
-          "actions": [
-            {
-              "name": "Create a Player",
-              "description": "Add a new player.\n\n",
-              "method": "POST",
-              "parameters": [],
-              "examples": [
-                {
-                  "name": "",
-                  "description": "",
-                  "requests": [
-                    {
-                      "name": "",
-                      "description": "",
-                      "headers": [
-                        {
-                          "name": "Content-Type",
-                          "value": "application/json"
-                        },
-                        {
-                          "name": "X-API-TOKEN",
-                          "value": "{{SOME_API_TOKEN}}"
-                        }
-                      ],
-                      "body": "{\n    \"name\": \"Craig\"\n}\n",
-                      "schema": ""
-                    }
-                  ],
-                  "responses": [
-                    {
-                      "name": "201",
-                      "description": "",
-                      "headers": [],
-                      "body": "",
-                      "schema": ""
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
+  "_version": "2.2",
+  "ast": {
+    "_version": "4.0",
+    "metadata": [
+      {
+        "name": "HOST",
+        "value": "https://foosball.pixelfusion.co.nz/v1"
+      },
+      {
+        "name": "FORMAT",
+        "value": "1A"
+      }
+    ],
+    "name": "Foosball API",
+    "description": "## Introduction\n\nThis is a simple API for keeping Foosball scores. It doesn't really exists and is just created to demonstrate the the <a href=\"http://git.io/api-blueprint-parser\" target=\"_blank\">API Blueprint Parser</a>.\n\n",
+    "resourceGroups": [
+      {
+        "name": "Players",
+        "description": "",
+        "resources": [
+          {
+            "name": "Player",
+            "description": "",
+            "uriTemplate": "/players",
+            "model": {},
+            "parameters": [],
+            "actions": [
+              {
+                "name": "Create a Player",
+                "description": "Add a new player.\n\n",
+                "method": "POST",
+                "parameters": [],
+                "examples": [
+                  {
+                    "name": "",
+                    "description": "",
+                    "requests": [
+                      {
+                        "name": "",
+                        "description": "",
+                        "headers": [
+                          {
+                            "name": "Content-Type",
+                            "value": "application/json"
+                          },
+                          {
+                            "name": "X-API-TOKEN",
+                            "value": "{{SOME_API_TOKEN}}"
+                          }
+                        ],
+                        "body": "{\n    \"name\": \"Craig\"\n}\n",
+                        "schema": ""
+                      }
+                    ],
+                    "responses": [
+                      {
+                        "name": "201",
+                        "description": "",
+                        "headers": [],
+                        "body": "",
+                        "schema": ""
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/test/api_non-ast.json
+++ b/test/api_non-ast.json
@@ -1,5 +1,5 @@
 {
-  "_version": "1.0",
+  "_version": "2.2",
   "metadata": [
     {
       "name": "HOST",


### PR DESCRIPTION
Blueman was throwing an exception on files created with the latest API Blueprint tools like Drafter because of the version number requirement. Removed this requirement and updated the code to support the AST format. Also updated the docs to make clear that Blueman only supports the AST format (which has been deprecated).