### PR TITLE
Use action name if possible

### DIFF
--- a/src/Blueman/Console/Command/ConvertCommand.php
+++ b/src/Blueman/Console/Command/ConvertCommand.php
@@ -148,7 +148,7 @@ EOT
                             $request['collectionId'] = $collection['id'];
                         }
                         $request['url'] = $host . $this->parseUri($resource, $action);
-                        $request['name'] = $resource->uriTemplate;
+                        $request['name'] = !empty($action->name) ? $action->name : $resource->uriTemplate;
                         $request['method'] = $action->method;
                         if($tests) {
                             $request['tests'] = $this->getTest($action->name, $tests);


### PR DESCRIPTION
I think it's nicer to have `Fetch a Resource` rather than `/resource/{id}` in the Postman sidebar
