### PR TITLE
Fixes on postman requests creation

### DIFF
--- a/src/Blueman/Console/Command/ConvertCommand.php
+++ b/src/Blueman/Console/Command/ConvertCommand.php
@@ -142,12 +142,12 @@ EOT
                                 $headers[] = sprintf('%s: %s', $header->name, $header->value);
                             }
                             $request['headers'] = implode("\n", $headers);
+                            $request['name'] = (string) $exampleRequest->name;
                             $request['data'] = (string) $exampleRequest->body;
                             $request['dataMode'] = 'raw';
                             $folders['order'][] = $request['id'];
                         }
                         $request['url'] = $host . $this->parseUri($resource, $action);
-                        $request['name'] = $resource->uriTemplate;
                         $request['method'] = $action->method;
                         $request['collectionId'] = $collection['id'];
                         $request['folder'] = $folders['id'];

--- a/src/Blueman/Console/Command/ConvertCommand.php
+++ b/src/Blueman/Console/Command/ConvertCommand.php
@@ -133,7 +133,6 @@ EOT
                 foreach ($resource->actions as $action) {
                     $actionId = (string)Uuid::uuid4();
 
-                    $folders['order'][] = $actionId;
 
                     foreach ($action->examples as $example) {
                         $request['id'] = (string) Uuid::uuid4();
@@ -145,12 +144,13 @@ EOT
                             $request['headers'] = implode("\n", $headers);
                             $request['data'] = (string) $exampleRequest->body;
                             $request['dataMode'] = 'raw';
+                            $folders['order'][] = $request['id'];
                         }
                         $request['url'] = $host . $this->parseUri($resource, $action);
                         $request['name'] = $resource->uriTemplate;
                         $request['method'] = $action->method;
                         $request['collectionId'] = $collection['id'];
-
+                        $request['folder'] = $folders['id'];
                         if ($tests) {
                             $request['tests'] = $this->getTest($action->name, $tests);
                         }

--- a/src/Blueman/Console/Command/ConvertCommand.php
+++ b/src/Blueman/Console/Command/ConvertCommand.php
@@ -136,7 +136,7 @@ EOT
                     $folders['order'][] = $actionId;
 
                     foreach ($action->examples as $example) {
-                        $request['id'] = $actionId;
+                        $request['id'] = (string) Uuid::uuid4();
                         foreach ($example->requests as $exampleRequest) {
                             $headers = array();
                             foreach ($exampleRequest->headers as $header) {


### PR DESCRIPTION
In the case of multiple example requests in an apiblueprint action section only one request appears. This is due to the use of the action ID as request id and a reference id in the folders population. 